### PR TITLE
Fix 'Pretty URL' rewrite

### DIFF
--- a/cloudfront-frontend-viewer-request-function.tf
+++ b/cloudfront-frontend-viewer-request-function.tf
@@ -2,7 +2,7 @@ data "template_file" "cloudfront_frontend_viewer_request_function" {
   template = file("${path.module}/cloudfront-functions/viewer-request.js")
 
   vars = {
-    append_empty_extension = local.enable_publii_pretty_urls ? "/" : ""
+    append_empty_extension = local.enable_publii_pretty_urls ? "/index.html" : ""
   }
 }
 


### PR DESCRIPTION
* The S3 bucket index_document only works for the root
* Setting the rewrite to '/index.html' for empty extensions fixes this
  issue