### PR TITLE
Fix CloudFront invalidation file trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It can in most cases be used to host any static site, however this module adds s
 
  - Creates an S3 bucket along with an IAM user which has the minimum required permissions to sync from [Publii][1]
  - Creates a CloudFront endpoint (And optionally ACM certificates and Route53 records in an existing Hosted Zone)
- - Creates a Lambda function to run a Cloudfront Invalidation when `files.publii.json` is created/updated (This file is updated on every sync)
+ - Creates a Lambda function to run a Cloudfront Invalidation when `sitemap.xml` is created/updated (This file is updated on every sync)
  - Optionally have CloudFront do the right thing when 'Pretty URLs' are enabled (This is achieved via a CloudFront function which adds `index.html` to the URI if there is no extention)
  - Optionally redirect from the apex domain (eg. example.com) to www (www.example.com). If this is enabled (`var.cloudfront_enable_apex_to_www_redirect`), the 'Website Url' within 'Server' options should be set to www.yourdomain.com - [Publii S3 Server Settings docs (point 26)][2]
  - Optionally enable WAF

--- a/s3-frontend.tf
+++ b/s3-frontend.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_notification" "frontend_cloudfront_invalidation" {
   lambda_function {
     lambda_function_arn = module.lambda_cloudfront_invalidation_frontend.function_arn
     events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = "files.publii.json"
+    filter_prefix       = "sitemap.xml"
   }
 
   depends_on = [aws_lambda_permission.cloudfront_invalidation_frontend_alllow_s3]


### PR DESCRIPTION
* `files.publii.json` is no longer uploaded to the S3 bucket, so a
  different file needs to be used as the trigger. `sitemap.xml` appears
  to be updated on every sync, so lets use that ...